### PR TITLE
Option to automatically configure delta lake

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -30,3 +30,6 @@ jobs:
       env:
         STAROID_ACCESS_TOKEN: ${{ secrets.staroid_access_token }}
         STAROID_ACCOUNT: ${{ secrets.staroid_account }}
+        S3_LOCATION: ${{ secrets.s3_location }}
+        AWS_ACCESS_KEY_ID: ${{ secrets.aws_access_key_id }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.aws_secret_access_key }}

--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,4 @@ dmypy.json
 
 py3/
 .vscode/
+it_test.sh

--- a/README.md
+++ b/README.md
@@ -16,35 +16,73 @@ pip install ods
 
 ## Quick start
 
-### Configuration
+### Initialize
 
-1. [Configure staroid](https://github.com/staroids/staroid-python#configuration)
+1. Login staroid.com and get an [access token](https://staroid.com/settings/accesstokens). And set `STAROID_ACCESS_TOKEN` environment variable. See [here](https://github.com/staroids/staroid-python#configuration) for more detail.
 2. Login staroid.com and create a SKE (Star Kubernetes engine) cluster.
 
 ```python
 import ods
-ods.init(ske="kube-cluster-1") # ske is a name of kubernetes cluster
+# 'ske' is the name of kubernetes cluster created from staroid.com. Alternatively, you can export 'STAROID_SKE' environment variable.
+ods.init(ske="kube-cluster-1")
 ```
 
-### Get Spark cluster
+## Spark
+
+### Create spark session
+Create spark session with default configuration
 
 ```python
-spark = ods.spark("spark-1", worker_num=3).session() # create spark session with 3 initial worker nodes
-
+import ods
+spark = ods.spark("spark-1") # 'spark-1' is name of spark-serverless instance to create.
 df = spark.createDataFrame(....)
 ```
 
-### Get Dask cluster (Coming soon)
+Configurue initial number of worker nodes
 
 ```python
+import ods
+spark = ods.spark("spark-1", worker_num=3).session()
+df = spark.createDataFrame(....)
+```
+
+`detal=True` to automatically download & configure delta lake
+
+```python
+import ods
+spark = ods.spark("spark-delta", delta=True)
+spark.read.format("delta").load(....)
+```
+
+pass `spark_conf` dictionary for additonal configuration
+
+```python
+import ods
+spark = ods.spark(spark_conf = {
+    "spark.hadoop.fs.s3a.access.key": "...",
+    "spark.hadoop.fs.s3a.secret.key" : "..."
+})
+```
+
+Check [tests/test_spark.py](https://github.com/open-datastudio/ods/blob/master/tests/test_spark.py) as well.
+
+## Dask
+
+Coming soon 🚛
+
+```python
+import ods
 cluster = ods.dask("dask-1", worker_num=10)
 
 from dask.distributed import Client
 client = Client(cluster)
 ```
 
-### Get Ray cluster (Coming soon)
+## Ray
+
+Coming soon 🚛
 
 ```python
+import ods
 ods.ray(cluster_name="")
 ```

--- a/ods/ods.py
+++ b/ods/ods.py
@@ -208,7 +208,6 @@ def init(ske=None):
     __singleton["instance"] = Ods(ske=ske)
     return __singleton["instance"]
 
-def spark(name, spark_conf=None, chisel_path=None, worker_num=1, worker_type="standard-4", worker_isolation="dedicated", delta=False, aws=False):
+def spark(name, spark_conf=None, chisel_path=None, worker_num=1, worker_type="standard-4", worker_isolation="dedicated", delta=False, aws=True):
     cluster = SparkCluster(__singleton["instance"], name, spark_conf=spark_conf, worker_num=worker_num, worker_type=worker_type, worker_isolation=worker_isolation, delta=delta, aws=aws)
     return cluster
-

--- a/ods/ods.py
+++ b/ods/ods.py
@@ -204,10 +204,13 @@ class Ods:
 
 __singleton = {}
 
-def init(ske=None):
-    __singleton["instance"] = Ods(ske=ske)
+def init(ske=None, reinit=True):
+    if "instance" not in __singleton or reinit:
+        __singleton["instance"] = Ods(ske=ske)
     return __singleton["instance"]
 
 def spark(name, spark_conf=None, chisel_path=None, worker_num=1, worker_type="standard-4", worker_isolation="dedicated", delta=False, aws=True):
+    init(reinit=False)
+
     cluster = SparkCluster(__singleton["instance"], name, spark_conf=spark_conf, worker_num=worker_num, worker_type=worker_type, worker_isolation=worker_isolation, delta=delta, aws=aws)
     return cluster


### PR DESCRIPTION
Add an option to automatically configure [delta lake](delta.io).

```
import ods
spark = ods.spark(delta=True)
```

will automatically add a proper version of delta library and configuration.
